### PR TITLE
Features/domain api/next round

### DIFF
--- a/DebateAppDomain/DebateApp.Domain/Debate.cs
+++ b/DebateAppDomain/DebateApp.Domain/Debate.cs
@@ -30,7 +30,13 @@ namespace DebateApp.Domain
         public double CurrentPotShareL { get; set; }
         public double CurrentPotShareR { get; set; }
         public string Status { get; set; }
+        public long RoundStart { get; set; }
+        public long LastGet { get; set; }
 
+        public void UpdateLastGet()
+        {
+            LastGet = DateTime.Now.Ticks;
+        }
         public void GetStage()
         {
             if (Teams.TrueForAll(t => t.ReadyToStart))
@@ -55,21 +61,34 @@ namespace DebateApp.Domain
                 Active = true
             };
             GetStage();
-  
+            
             if(_gamestage)
             {
+                RoundStart = DateTime.Now.Ticks;
                 Round.Add(new RoundState(StartingRound));
                 foreach(User u in Audience)
                 {
                     Pot += 4;
                 }
                 var ar = this.ActiveRound();
-                Status = "Round " + ar.CurrentTurn;
+                Status = "Round " + ar.CurrentTurn + "has started!";
             }
             else
             {
                 Status = "Debate is still in Setup Stage!";
             }
+        }
+
+        public void CheckNextRound()
+        {
+            UpdateLastGet();
+            var seconds = (LastGet - RoundStart)/(10000*1000);
+            if (seconds >= TurnLength)
+            {
+                NextRound(true);
+            }
+            else { NextRound(false); }
+            
         }
 
         public bool HaveAllVoted()
@@ -90,6 +109,9 @@ namespace DebateApp.Domain
             var RoundCanEnd = (!timer && HaveAllResponded() && HaveAllVoted());
             if (timer || RoundCanEnd)
             {
+                //restart RoundStart
+                RoundStart = DateTime.Now.Ticks;
+                
                 //set all previous rounds to active = false
                 foreach (RoundState r in Round)
                 {

--- a/DebateAppDomain/DebateApp.Domain/Debate.cs
+++ b/DebateAppDomain/DebateApp.Domain/Debate.cs
@@ -106,7 +106,7 @@ namespace DebateApp.Domain
 
         public void NextRound(bool timer)
         {
-            var RoundCanEnd = (!timer && HaveAllResponded() && HaveAllVoted());
+            var RoundCanEnd = (HaveAllResponded() && HaveAllVoted());
             if (timer || RoundCanEnd)
             {
                 //restart RoundStart

--- a/DebateAppDomain/DebateApp.Domain/DebatePost.cs
+++ b/DebateAppDomain/DebateApp.Domain/DebatePost.cs
@@ -11,10 +11,10 @@ namespace DebateApp.Domain
         public string CommentText { get; set; }
         public string TimeStamp { get; set; }
         public int UserID { get; set; }
-        public int MaxLength { get; set; }
+        //public int MaxLength { get; set; }
         //public string Team { get; set; }
         //public Dictionary<String, String> Sources { get; set; }
-        public int DebateID { get; set; }
+        //public int DebateID { get; set; }
         public DebatePost(string s, int uid)
         {
             CommentText = s;

--- a/DebateAppDomain/DebateApp.Domain/RoundState.cs
+++ b/DebateAppDomain/DebateApp.Domain/RoundState.cs
@@ -45,12 +45,12 @@ namespace DebateApp.Domain
         {
             if(team)
             {
-                VotesL += 1;
+                VotesR += 1;
                
             }
             if(!team)
             {
-                VotesR += 1;
+                VotesL += 1;
                 
             }
         }

--- a/DebateAppDomain/DebateApp.Domain/User.cs
+++ b/DebateAppDomain/DebateApp.Domain/User.cs
@@ -44,8 +44,9 @@ namespace DebateApp.Domain
         }
         public Debate Vote(Debate d, bool team)
         {
-           
-            if (HasVoted == false && d.Audience.Contains(this))
+
+            var check = HasVoted == false && d.Audience.Exists(u => u.UserID == this.UserID);
+            if (check)
             {
                 d.ActiveRound().Vote(team);
                 HasVoted = true;

--- a/DebateAppDomain/DebateApp.Test/DebateShould.cs
+++ b/DebateAppDomain/DebateApp.Test/DebateShould.cs
@@ -1,6 +1,7 @@
 using DebateApp.Domain;
 
 using System;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -41,7 +42,12 @@ namespace DebateApp.Test
             dut_joined.StartDebate();
 
             var dut_posted = uut2.Post("FUCK YOU!", dut_joined);
-            dut_posted.NextRound(true);
+            dut_posted.CheckNextRound();
+            Thread.Sleep(10000);
+            dut_posted.CheckNextRound();
+            Assert.Equal(1, dut_posted.Round.Count);
+            Thread.Sleep(51000);
+            dut_posted.CheckNextRound();
             Assert.Equal(2, dut_posted.Round.Count);
             Assert.Equal(dut_posted.CurrentPotShareL, 5);
             Assert.Equal(dut_posted.CurrentPotShareR, 5);
@@ -50,10 +56,11 @@ namespace DebateApp.Test
             var dut_audience = uut3.ViewDebate(dut_posted3);
             var dut_allvoted = uut3.Vote(dut_audience, true);
 
-            dut_allvoted.NextRound(false);
+            dut_allvoted.CheckNextRound();
             Assert.Equal(dut_allvoted.Round.Count, 3);
             Assert.Equal(dut_allvoted.CurrentPotShareR, .25 * 14);
             Assert.Equal(dut_allvoted.CurrentPotShareL, .75 * 14);
+
         }
     }
 }

--- a/DebateAppDomain/DebateApp.Test/DebatesControllerShould.cs
+++ b/DebateAppDomain/DebateApp.Test/DebatesControllerShould.cs
@@ -61,5 +61,7 @@ namespace DebateAppDomain.Test
 
 
 
+
+
     }
 }

--- a/DebateAppDomain/DebateApp.Test/UserControllerShould.cs
+++ b/DebateAppDomain/DebateApp.Test/UserControllerShould.cs
@@ -98,5 +98,35 @@ namespace DebateAppDomain.Test
 
             Assert.True(dmut.d.ActiveRound().VotesR == 1);
         }
+        [Fact]
+        public void MakeAPost()
+        {
+
+            var dmut = dbcut.CreateCasual(ccm);
+            var id = dmut.d.Debate_ID;
+            var biggo = UCUT.RegisterUser(umut);
+            dmut = UCUT.JoinAudience(new FormDataModels.UserDebateModel(id, "SteveHarvey2"));
+            var simulatedJoinTeam = new FormDataModels.JoinDebateModel()
+            {
+                username = "Biggo",
+                DebateID = id,
+                Opener = "NO! NOOOOOOO"
+            };
+            dmut = UCUT.JoinTeam(simulatedJoinTeam);
+            dmut = dbcut.StartDebate(dmut.d.Debate_ID);
+            var pm = new FormDataModels.PostModel()
+            {
+                DebateId = id,
+                Comment = "Fuck alla yas",
+                UserId = 2
+            };
+
+            dmut = UCUT.Post(pm);
+
+            Assert.Equal(1, dmut.d.ActiveRound().Responses.Count);
+            Assert.Equal("Fuck alla yas", dmut.d.ActiveRound().Responses[0].CommentText);
+        }
+
+
     }
 }

--- a/DebateAppDomain/DebateApp.Test/UserControllerShould.cs
+++ b/DebateAppDomain/DebateApp.Test/UserControllerShould.cs
@@ -79,5 +79,24 @@ namespace DebateAppDomain.Test
             dbh.DBDeleteDebate(id);
             _output.WriteLine(JsonConvert.SerializeObject(actual));
         }
+        [Fact]
+        public void CastAVote()
+        {
+            var dmut = dbcut.CreateCasual(ccm);
+            var id = dmut.d.Debate_ID;
+            var biggo = UCUT.RegisterUser(umut);
+            dmut = UCUT.JoinAudience(new FormDataModels.UserDebateModel(id, "SteveHarvey2"));
+            var simulatedJoinTeam = new FormDataModels.JoinDebateModel()
+            {
+                username = "Biggo",
+                DebateID = id,
+                Opener = "NO! NOOOOOOO"
+            };
+            dmut = UCUT.JoinTeam(simulatedJoinTeam);
+            dmut = dbcut.StartDebate(dmut.d.Debate_ID);
+            dmut = UCUT.Vote(new FormDataModels.VoteModel(20, id, true));
+
+            Assert.True(dmut.d.ActiveRound().VotesR == 1);
+        }
     }
 }

--- a/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
@@ -54,7 +54,9 @@ namespace DebateAppDomainAPI.Controllers
         [HttpGet("{id}")]
         public DebateModel StartDebate(int id)
         {
-            return _dbh.StartDebate(id);
+            var result = _dbh.StartDebate(id);
+            _dbh.DBSaveDebateChanges(result);
+            return result;
         }
 
         //[HttpPut("{id}")]

--- a/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
@@ -57,11 +57,11 @@ namespace DebateAppDomainAPI.Controllers
             return _dbh.StartDebate(id);
         }
 
-        [HttpPut("{id}")]
-        public DebateModel NextRound(int id, [FromBody]bool value)
-        {
-            return _dbh.NextRound(id, value);
-        }
+        //[HttpPut("{id}")]
+        //public DebateModel NextRound(int id, [FromBody]bool value)
+        //{
+        //    return _dbh.NextRound(id, value);
+        //}
 
     }
 }

--- a/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
@@ -38,6 +38,7 @@ namespace DebateAppDomainAPI.Controllers
         {
             var get = _dbh.DBGetDebate(id);
             get.d.CheckNextRound();
+            _dbh.DBSaveDebateChanges(get);
             return get;
         }
 

--- a/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
@@ -37,8 +37,11 @@ namespace DebateAppDomainAPI.Controllers
         public DebateModel GetDebate(int id)
         {
             var get = _dbh.DBGetDebate(id);
-            get.d.CheckNextRound();
-            _dbh.DBSaveDebateChanges(get);
+            if (get.d._gamestage)
+            {
+                get.d.CheckNextRound();
+                _dbh.DBSaveDebateChanges(get);
+            }
             return get;
         }
 

--- a/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Controllers/DebatesController.cs
@@ -20,7 +20,7 @@ namespace DebateAppDomainAPI.Controllers
         //Create Casual expects an httppost with form data in the following format:
         //int UserID =
         //string Topic = 
-        //string Category =
+        //string Category = 
         //string Opener = 
         public DebateModel CreateCasual([FromBody]FormDataModels.CreateCasualModel cm)
         {
@@ -36,7 +36,9 @@ namespace DebateAppDomainAPI.Controllers
         [HttpGet("{id}")]
         public DebateModel GetDebate(int id)
         {
-            return _dbh.DBGetDebate(id);
+            var get = _dbh.DBGetDebate(id);
+            get.d.CheckNextRound();
+            return get;
         }
 
         [HttpGet]

--- a/DebateAppDomain/DebateAppDomainAPI/Controllers/UserController.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Controllers/UserController.cs
@@ -84,19 +84,20 @@ namespace DebateAppDomainAPI.Controllers
         [HttpPut]
         public DebateModel Vote([FromBody]FormDataModels.VoteModel voteModel)
         {
-            _dbh.Vote(voteModel.UserId, voteModel.Debate, voteModel.Team);
-            _dbh.DBSaveDebateChanges(voteModel.Debate);
+            var d = _dbh.DBGetDebate(voteModel.DebateId);
+            var res = _dbh.Vote(voteModel.UserId, d, voteModel.Team);
+            _dbh.DBSaveDebateChanges(res);
 
-            return voteModel.Debate;
+            return res;
         }
 
         [HttpPut]
         public DebateModel Post([FromBody]FormDataModels.PostModel postModel)
         {
-            _dbh.Post(postModel.UserId, postModel.Comment, postModel.Debate);
-            _dbh.DBSaveDebateChanges(postModel.Debate);
+            var result = _dbh.Post(postModel.UserId, postModel.Comment, postModel.DebateId);
+            _dbh.DBSaveDebateChanges(result);
 
-            return postModel.Debate;
+            return result;
         }
         [HttpPost]
         public DebateModel JoinAudience([FromBody]FormDataModels.UserDebateModel udm)

--- a/DebateAppDomain/DebateAppDomainAPI/Models/DBHelper.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Models/DBHelper.cs
@@ -160,7 +160,6 @@ namespace DebateAppDomainAPI.Models
             var d = DBGetDebate(debateid);
             var updatedDebate = user.UserLogic.Post(comment, d.d);
             d.d = updatedDebate;
-
             return d;
         }
 

--- a/DebateAppDomain/DebateAppDomainAPI/Models/DBHelper.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Models/DBHelper.cs
@@ -146,19 +146,22 @@ namespace DebateAppDomainAPI.Models
         public DebateModel Vote(int id, DebateModel debate, bool value)
         {
             var user = DBGetUser(id);
+            user.Transfer();
             var updatedDebate = user.UserLogic.Vote(debate.d, value);
             debate.d = updatedDebate;
 
             return debate;
         }
 
-        public DebateModel Post(int id, string comment, DebateModel debate)
+        public DebateModel Post(int id, string comment, int debateid)
         {
             var user = DBGetUser(id);
-            var updatedDebate = user.UserLogic.Post(comment, debate.d);
-            debate.d = updatedDebate;
+            user.Transfer();
+            var d = DBGetDebate(debateid);
+            var updatedDebate = user.UserLogic.Post(comment, d.d);
+            d.d = updatedDebate;
 
-            return debate;
+            return d;
         }
 
     }

--- a/DebateAppDomain/DebateAppDomainAPI/Models/DBHelper.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Models/DBHelper.cs
@@ -110,6 +110,7 @@ namespace DebateAppDomainAPI.Models
 
         public void DBSaveDebateChanges(DebateModel d)
         {
+            d.d.UpdateLastGet();
             var body = new StringContent(JsonConvert.SerializeObject(d), Encoding.UTF8, "application/json");
             var cd = _client.PutAsync(_api + PutDebate + d.d.Debate_ID, body).GetAwaiter().GetResult();
         }
@@ -124,14 +125,14 @@ namespace DebateAppDomainAPI.Models
             _client.DeleteAsync(_api + "Accounts/" + id).GetAwaiter().GetResult();
         }
 
-        public DebateModel NextRound(int id, bool value)
-        {
-            var debate = DBGetDebate(id);
+        //public DebateModel NextRound(int id, bool value)
+        //{
+        //    var debate = DBGetDebate(id);
 
-            debate.d.NextRound(value);
+        //    debate.d.NextRound(value);
 
-            return debate;
-        }
+        //    return debate;
+        //}
 
         public DebateModel StartDebate(int id)
         {

--- a/DebateAppDomain/DebateAppDomainAPI/Models/FormDataModels.cs
+++ b/DebateAppDomain/DebateAppDomainAPI/Models/FormDataModels.cs
@@ -25,20 +25,31 @@ namespace DebateAppDomainAPI.Models
         public class VoteModel
         {
             public int UserId { get; set; }
-            public DebateModel Debate { get; set; }
+            public int DebateId { get; set; }
             public bool Team { get; set; }
+            public VoteModel(int userid, int debateid, bool team)
+            {
+                UserId = userid;
+                DebateId = debateid;
+                Team = team;
+            }
         }
         public class PostModel
         {
             public int UserId { get; set; }
-            public DebateModel Debate { get; set; }
+            public int DebateId { get; set; }
             public string Comment { get; set; }
         }
 
         public class UserDebateModel
         {
             public int DebateID { get; set; }
-            public int Username { get; set; }
+            public string Username { get; set; }
+            public UserDebateModel(int did, string username)
+            {
+                DebateID = did;
+                Username = username;
+            }
         }
     }
 }


### PR DESCRIPTION
nextround will now be automatically triggered based on timestamps that are updated each time the api gets the debate in question. It will also be automatically triggered if all votes have been cast from the audience and all debaters have responded.
Post and Vote service methods tested successfully